### PR TITLE
Use max acceleration to calculate waypoint speeds

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -45,6 +45,7 @@ class WaypointUpdater(object):
 
         # Save next red traffic light waypoint
         self.red_tl_wp = None
+        self.speed = 0.0
 
         #rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         self.base_waypoints_sub = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
@@ -107,39 +108,50 @@ class WaypointUpdater(object):
             else:
                 waypoint_index += 1
 
+
+        steps = final_wp - next_wp
+        indexes = range(steps)
+
         # Slow down vehicle by very simple step function
         if enable_slow_down:
-
-            steps = final_wp - next_wp
-            indexes = range(steps)
-
             # want to start at the traffic light and work way back to current speed
             indexes.reverse()
+            self.speed = 0
 
-            speed = 0
             prev_waypoint = None
-            zero_count = 0
+            zero_speed_count = 0
             for i in indexes:
                 waypoint = final_waypoints.waypoints[i]
 
                 # distance between waypoints 
                 if prev_waypoint is None:
                     pass
-                elif zero_count < MIN_ZERO_WP:
+                elif zero_speed_count < MIN_ZERO_WP:
                     # set the waypoints near the TL to zero
                     # need a few to make the car stop before the TL
-                    zero_count += 1
-                elif speed < self.target_velocity:
-                    # Now calculate the sped at each waypoint taking into account the allowable acceleration/deceleration
-                    # work our way back from the traffic light.
-                    distance = self.distance(waypoint.pose.pose.position, prev_waypoint.pose.pose.position)
-                    # update next speed based on MAX Acceleration/Deceleration and d = vt + 0.5at**2
-                    time_to_waypoint = 2*distance/(speed + math.sqrt(speed**2 + 2*MAX_ACCEL*distance))
-                    speed = speed + MAX_ACCEL*time_to_waypoint
-                    if speed > self.target_velocity:
-                        speed = self.target_velocity
-                self.set_waypoint_velocity(final_waypoints.waypoints, i, speed)
+                    zero_speed_count += 1
+                elif self.speed < self.target_velocity:
+                    self.speed = self.Accelerate(waypoint, prev_waypoint, self.speed, self.target_velocity, MAX_ACCEL);
+
+                self.set_waypoint_velocity(final_waypoints.waypoints, i, self.speed)
                 prev_waypoint = waypoint
+        else:
+            # either speed up or coast
+            prev_waypoint = None
+
+            for i in indexes:
+                waypoint = final_waypoints.waypoints[i]
+                if prev_waypoint is None:
+                    pass
+                elif self.speed < self.target_velocity:
+                    self.speed = self.Accelerate(waypoint, prev_waypoint, self.speed, self.target_velocity, MAX_ACCEL);
+                else:
+                    # we have reached the target velocity so no more accelerating to do
+                    break
+
+                self.set_waypoint_velocity(final_waypoints.waypoints, i, self.speed)
+                prev_waypoint = waypoint
+
 
         # Publish the complete waypoint list
         self.final_waypoints_pub.publish(final_waypoints)
@@ -239,6 +251,16 @@ class WaypointUpdater(object):
         #    dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
         #    wp1 = i
         return dist
+
+    def Accelerate(self, waypoint, prev_waypoint, speed, target_speed, max_accel):
+        # Calculate the speed at each waypoint taking into account the allowable acceleration/deceleration
+        distance = self.distance(waypoint.pose.pose.position, prev_waypoint.pose.pose.position)
+        # update next speed based on MAX Acceleration/Deceleration and d = vt + 0.5at**2
+        time_to_waypoint = 2*distance/(speed + math.sqrt(speed**2 + 2*max_accel*distance))
+        speed = speed + max_accel*time_to_waypoint
+        if speed > target_speed:
+            speed = target_speed
+        return speed
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updated the waypoint velocities when stopping for TL using MAX ACCELERATION parameter.
This should stop the vehicle decelerating at a rate that is not permitted.

Feel free to test locally.